### PR TITLE
Update ToolBarItems of TabbedPage from Child when Page Changes

### DIFF
--- a/Naxam.TopTabbedPage.Platform.iOS/TopTabbedRendererSelection.cs
+++ b/Naxam.TopTabbedPage.Platform.iOS/TopTabbedRendererSelection.cs
@@ -19,6 +19,8 @@ namespace Naxam.Controls.Platform.iOS
         void HandleTabsSelectionChanged(object sender, TabsSelectionChangedEventArgs e)
         {
             MoveToByIndex((int)e.SelectedIndex);
+            var navigationItem = this.NavigationController.TopViewController.NavigationItem;
+            navigationItem.SetRightBarButtonItems(newChild.ToolbarItems.Select(x=>x.ToUIBarButtonItem()).ToArray(), false);            
         }
 
         void MoveToByIndex(int selectedIndex, bool forced = false)


### PR DESCRIPTION
The ToolbarItems of the TopTabbedPage parent was only updating once, when the TopTabbedPage was initially created, and was set to the ToolBarItems of the first child tab.  Selecting a different tab would not update the ToolBar, which this little tweak fixes.